### PR TITLE
Process/Threads count metrics and check

### DIFF
--- a/bin/check-threads-count.rb
+++ b/bin/check-threads-count.rb
@@ -78,7 +78,7 @@ class ThreadsCount < Sensu::Plugin::Check::CLI
   def run
     check_proctable_version
     ps_table = Sys::ProcTable.ps
-    threads = ps_table.inject(0) do |sum, p|
+    threads = ps_table.reduce(0) do |sum, p|
       sum + get_process_threads(p)
     end
 

--- a/bin/check-threads-count.rb
+++ b/bin/check-threads-count.rb
@@ -52,7 +52,7 @@ class ThreadsCount < Sensu::Plugin::Check::CLI
 
   # Exit with an unknown if sys-proctable is not high enough to support counting threads.
   def check_proctable_version
-    Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5') 
+    Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5')
   end
 
   # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1.

--- a/bin/check-threads-count.rb
+++ b/bin/check-threads-count.rb
@@ -52,7 +52,7 @@ class ThreadsCount < Sensu::Plugin::Check::CLI
 
   # Exit with an unknown if sys-proctable is not high enough to support counting threads.
   def check_proctable_version
-    Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5') ? true : false
+    Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5') 
   end
 
   # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1.

--- a/bin/check-threads-count.rb
+++ b/bin/check-threads-count.rb
@@ -1,0 +1,87 @@
+#! /usr/bin/env ruby
+#
+#   check-threads-count.rb
+#
+# DESCRIPTION:
+#   Counts the number of threads running on the system and alerts if that number is greater than the warning or critical values.
+#   The default warning and critical count thresholds come from the ~32000 thread limit in older Linux kernels.
+#
+# OUTPUT:
+#   check
+#
+# PLATFORMS:
+#   Linux, Windows
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: sys-proctable
+#
+# USAGE:
+#   The check will return an UNKNOWN if the sys-proctable version is not new enough to support it.
+#
+# NOTES:
+#   sys-proctable > 0.9.5 is required for counting threads
+#
+# LICENSE:
+#   Copyright (c) 2015 Contegix LLC
+#   Richard Chatteron richard.chatterton@contegix.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'sys/proctable'
+
+class ThreadsCount < Sensu::Plugin::Check::CLI
+  option :warn,
+         description: 'Produce a warning if the total number of threads is greater than this value.',
+         short: '-w WARN',
+         default: 30000,
+         proc: proc(&:to_i)
+
+  option :crit,
+         description: 'Produce a critical if the total number of threads is greater than this value.',
+         short: '-c CRIT',
+         default: 32000,
+         proc: proc(&:to_i)
+
+  # Exit with an unknown if sys-proctable is not high enough to support counting threads.
+  def check_proctable_version
+    unless Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5')
+      unknown "sys-proctable version newer than 0.9.5 is required for counting threads with -t or --threads"
+    end
+  end
+
+  # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1. 
+  # See the comments on get_process_threads() for why 1 is returned.
+  def test_int(i)
+    return Integer(i) rescue return 1
+  end
+
+  # Takes a process struct from Sys::ProcTable.ps() as an argument
+  # Attempts to use the Linux thread count field :nlwp first, then tries the Windows field :thread_count.
+  # Returns the number of processes in those fields.
+  # Otherwise, returns 1 as all processes are assumed to have at least one thread.
+  def get_process_threads(p)
+    if p.respond_to?(:nlwp)
+      return test_int(p.nlwp)
+    elsif p.respond_to?(:thread_count)
+      return test_int(p.thread_count)
+    else
+      return 1
+    end
+  end
+
+  # Main function
+  def run
+    check_proctable_version 
+    ps_table = Sys::ProcTable.ps
+    threads = ps_table.inject(0) do |sum, p|
+      sum + get_process_threads(p)
+    end
+    
+    critical "#{threads} threads running, over threshold #{config[:crit]}" if threads > config[:crit]
+    warning "#{threads} threads running, over threshold #{config[:warn]}" if threads > config[:warn]
+    ok "#{threads} threads running"
+  end
+end

--- a/bin/metrics-processes-threads-count.rb
+++ b/bin/metrics-processes-threads-count.rb
@@ -82,7 +82,7 @@ class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
     ps_table = Sys::ProcTable.ps
     processes = ps_table.length
     if config[:threads]
-      threads = ps_table.inject(0) do |sum, p|
+      threads = ps_table.reduce(0) do |sum, p|
         sum + get_process_threads(p)
       end
     end

--- a/bin/metrics-processes-threads-count.rb
+++ b/bin/metrics-processes-threads-count.rb
@@ -1,0 +1,95 @@
+#! /usr/bin/env ruby
+#
+#   metric-processes-threads-count.rb
+#
+# DESCRIPTION:
+#   Counts the number of processes running on the system (and optionally, the number of running threads) and outputs it in metric format.
+#   Can alternatively count the number of processes/threads matching a certain substring.
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux, Windows
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: sys-proctable
+#
+# USAGE:
+#   Pass [-t|--threads] to count the number of running threads in addition to processes.
+#   The check will return an UNKNOWN if the sys-proctable version is not new enough to support it.
+#
+# NOTES:
+#   sys-proctable > 0.9.5 is required for counting threads (-t, --threads)
+#
+# LICENSE:
+#   Copyright (c) 2015 Contegix LLC
+#   Richard Chatteron richard.chatterton@contegix.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/metric/cli'
+require 'sys/proctable'
+
+class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+         description: 'Scheme for metric output',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: 'system'
+
+  option :threads,
+         description: 'If specified, count the number of threads running on the system in addition to processes. Note: Requires sys-proctables > 0.9.5',
+         short: '-t',
+         long: '--threads',
+         boolean: true,
+         default: false
+
+  # Exit with an unknown if sys-proctable is not high enough to support counting threads.
+  def check_proctable_version
+    unless Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5')
+      unknown "sys-proctable version newer than 0.9.5 is required for counting threads with -t or --threads"
+    end
+  end
+
+  # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1. 
+  # See the comments on get_process_threads() for why 1 is returned.
+  def test_int(i)
+    return Integer(i) rescue return 1
+  end
+
+  # Takes a process struct from Sys::ProcTable.ps() as an argument
+  # Attempts to use the Linux thread count field :nlwp first, then tries the Windows field :thread_count.
+  # Returns the number of processes in those fields.
+  # Otherwise, returns 1 as all processes are assumed to have at least one thread.
+  def get_process_threads(p)
+    if p.respond_to?(:nlwp)
+      return test_int(p.nlwp)
+    elsif p.respond_to?(:thread_count)
+      return test_int(p.thread_count)
+    else
+      return 1
+    end
+  end
+
+  # Main function
+  def run
+    check_proctable_version if config[:threads]
+    ps_table = Sys::ProcTable.ps
+    processes = ps_table.length
+    if config[:threads]
+      threads = ps_table.inject(0) do |sum, p|
+        sum + get_process_threads(p)
+      end
+    end
+    
+    timestamp = Time.now.to_i
+    output "#{[ config[:scheme], 'process_count' ].join('.')} #{processes} #{timestamp}"
+    if config[:threads]
+      output "#{[ config[:scheme], 'thread_count' ].join('.')} #{threads} #{timestamp}"
+    end
+    ok
+  end
+end

--- a/bin/metrics-processes-threads-count.rb
+++ b/bin/metrics-processes-threads-count.rb
@@ -18,7 +18,7 @@
 #
 # USAGE:
 #   Pass [-t|--threads] to count the number of running threads in addition to processes.
-#   The check will return an UNKNOWN if the sys-proctable version is not new enough to support it.
+#   The check will return an UNKNOWN if the sys-proctable version is not new enough to support counting threads.
 #
 # NOTES:
 #   sys-proctable > 0.9.5 is required for counting threads (-t, --threads)
@@ -33,6 +33,9 @@
 require 'sensu-plugin/metric/cli'
 require 'sys/proctable'
 
+#
+# Processes and Threads Count Metrics
+#
 class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,
          description: 'Scheme for metric output',
@@ -49,12 +52,11 @@ class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
 
   # Exit with an unknown if sys-proctable is not high enough to support counting threads.
   def check_proctable_version
-    unless Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5')
-      unknown "sys-proctable version newer than 0.9.5 is required for counting threads with -t or --threads"
-    end
+    msg = 'sys-proctable version newer than 0.9.5 is required for counting threads with -t or --threads'
+    unknown msg unless Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5')
   end
 
-  # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1. 
+  # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1.
   # See the comments on get_process_threads() for why 1 is returned.
   def test_int(i)
     return Integer(i) rescue return 1
@@ -84,11 +86,11 @@ class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
         sum + get_process_threads(p)
       end
     end
-    
+
     timestamp = Time.now.to_i
-    output "#{[ config[:scheme], 'process_count' ].join('.')} #{processes} #{timestamp}"
+    output "#{[config[:scheme], 'process_count'].join('.')} #{processes} #{timestamp}"
     if config[:threads]
-      output "#{[ config[:scheme], 'thread_count' ].join('.')} #{threads} #{timestamp}"
+      output "#{[config[:scheme], 'thread_count'].join('.')} #{threads} #{timestamp}"
     end
     ok
   end

--- a/lib/sensu-plugins-process-checks.rb
+++ b/lib/sensu-plugins-process-checks.rb
@@ -4,5 +4,4 @@
 module SensuPluginsProcessChecks
   # Gem version
   VERSION = '0.0.1.alpha.3'
-
 end

--- a/sensu-plugins-process-checks.gemspec
+++ b/sensu-plugins-process-checks.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'english',           '0.6.3'
   s.add_runtime_dependency 'sensu-plugin',      '1.1.0'
   s.add_runtime_dependency 'json',              '1.8.2'
+  s.add_runtime_dependency 'sys-proctable',     '0.9.6'
 
   s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'rubocop',       '~> 0.17.0'

--- a/test/check-threads-count_spec.rb
+++ b/test/check-threads-count_spec.rb
@@ -35,16 +35,16 @@ describe ThreadsCount, 'count_threads' do
   # Here, we mock Sys::ProcTable.ps() to return an array of structs with only the property this class cares about.
   #
   it 'should be able to count threads from ProcTable structs with :nlwp fields' do
-    NLWPEntry = Struct.new(:nlwp)
-    table = [NLWPEntry.new(3), NLWPEntry.new(1), NLWPEntry.new(6)]
+    nlwp_entry = Struct.new(:nlwp)
+    table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]
     allow(Sys::ProcTable).to receive(:ps).and_return(table)
     threadscount = ThreadsCount.new
     expect(threadscount.count_threads).to eq(10)
   end
 
   it 'should be able to count threads from ProcTable structs with :thread_count fields' do
-    TCEntry = Struct.new(:thread_count)
-    table = [TCEntry.new(3), TCEntry.new(1), TCEntry.new(6)]
+    tc_entry = Struct.new(:thread_count)
+    table = [tc_entry.new(3), tc_entry.new(1), tc_entry.new(6)]
     allow(Sys::ProcTable).to receive(:ps).and_return(table)
     threadscount = ThreadsCount.new
     expect(threadscount.count_threads).to eq(10)

--- a/test/check-threads-count_spec.rb
+++ b/test/check-threads-count_spec.rb
@@ -15,7 +15,7 @@ describe ThreadsCount, 'count_threads' do
   #
   it 'should be able to count threads from ProcTable structs with :nlwp fields' do
     NLWPEntry = Struct.new(:nlwp)
-    table = [ NLWPEntry.new(3), NLWPEntry.new(1), NLWPEntry.new(6) ]
+    table = [NLWPEntry.new(3), NLWPEntry.new(1), NLWPEntry.new(6)]
     allow(Sys::ProcTable).to receive(:ps).and_return(table)
     threadscount = ThreadsCount.new
     expect(threadscount.count_threads).to eq(10)
@@ -23,7 +23,7 @@ describe ThreadsCount, 'count_threads' do
 
   it 'should be able to count threads from ProcTable structs with :thread_count fields' do
     TCEntry = Struct.new(:thread_count)
-    table = [ TCEntry.new(3), TCEntry.new(1), TCEntry.new(6) ]
+    table = [TCEntry.new(3), TCEntry.new(1), TCEntry.new(6)]
     allow(Sys::ProcTable).to receive(:ps).and_return(table)
     threadscount = ThreadsCount.new
     expect(threadscount.count_threads).to eq(10)
@@ -47,7 +47,7 @@ describe ThreadsCount, 'run' do
     threadscount.config[:crit] = 15
     allow(threadscount).to receive(:count_threads).and_return(20)
     expect(threadscount).to receive(:critical)
-    expect(lambda { threadscount.run }).to raise_error SystemExit
+    expect(-> { threadscount.run }).to raise_error SystemExit
   end
 
   it 'returns warning if count_threads returns more than the warning threshold' do
@@ -56,7 +56,7 @@ describe ThreadsCount, 'run' do
     threadscount.config[:crit] = 30
     allow(threadscount).to receive(:count_threads).and_return(20)
     expect(threadscount).to receive(:warning)
-    expect(lambda { threadscount.run }).to raise_error SystemExit
+    expect(-> { threadscount.run }).to raise_error SystemExit
   end
 
   it 'returns ok if count_threads returns less than the critical or warning thresholds' do
@@ -69,4 +69,3 @@ describe ThreadsCount, 'run' do
   end
 
 end
-

--- a/test/check-threads-count_spec.rb
+++ b/test/check-threads-count_spec.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+#
+
+require_relative './plugin_stub.rb'
+require_relative './spec_helper.rb'
+require_relative '../bin/check-threads-count.rb'
+
+RSpec.configure do |c|
+  c.before { allow($stdout).to receive(:puts) }
+  c.before { allow($stderr).to receive(:puts) }
+end
+
+describe ThreadsCount, 'count_threads' do
+  # Here, we mock Sys::ProcTable.ps() to return an array of structs with only the property this class cares about.
+  #
+  it 'should be able to count threads from ProcTable structs with :nlwp fields' do
+    NLWPEntry = Struct.new(:nlwp)
+    table = [ NLWPEntry.new(3), NLWPEntry.new(1), NLWPEntry.new(6) ]
+    allow(Sys::ProcTable).to receive(:ps).and_return(table)
+    threadscount = ThreadsCount.new
+    expect(threadscount.count_threads).to eq(10)
+  end
+
+  it 'should be able to count threads from ProcTable structs with :thread_count fields' do
+    TCEntry = Struct.new(:thread_count)
+    table = [ TCEntry.new(3), TCEntry.new(1), TCEntry.new(6) ]
+    allow(Sys::ProcTable).to receive(:ps).and_return(table)
+    threadscount = ThreadsCount.new
+    expect(threadscount.count_threads).to eq(10)
+  end
+
+end
+
+describe ThreadsCount, 'run' do
+
+  it 'returns unknown if check_proctable_version returns false' do
+    threadscount = ThreadsCount.new
+    allow(threadscount).to receive(:count_threads).and_return(0)
+    allow(threadscount).to receive(:check_proctable_version) { false }
+    expect(threadscount).to receive(:unknown)
+    threadscount.run
+  end
+
+  it 'returns critical if count_threads returns more than the critical threshold' do
+    threadscount = ThreadsCount.new
+    threadscount.config[:warn] = 10
+    threadscount.config[:crit] = 15
+    allow(threadscount).to receive(:count_threads).and_return(20)
+    expect(threadscount).to receive(:critical)
+    expect(lambda { threadscount.run }).to raise_error SystemExit
+  end
+
+  it 'returns warning if count_threads returns more than the warning threshold' do
+    threadscount = ThreadsCount.new
+    threadscount.config[:warn] = 10
+    threadscount.config[:crit] = 30
+    allow(threadscount).to receive(:count_threads).and_return(20)
+    expect(threadscount).to receive(:warning)
+    expect(lambda { threadscount.run }).to raise_error SystemExit
+  end
+
+  it 'returns ok if count_threads returns less than the critical or warning thresholds' do
+    threadscount = ThreadsCount.new
+    threadscount.config[:warn] = 10
+    threadscount.config[:crit] = 20
+    allow(threadscount).to receive(:count_threads).and_return(5)
+    expect(threadscount).to receive(:ok)
+    threadscount.run
+  end
+
+end
+

--- a/test/check-threads-count_spec.rb
+++ b/test/check-threads-count_spec.rb
@@ -1,6 +1,27 @@
 #!/usr/bin/env ruby
 #
-
+# check-threads-count_spec
+#
+# DESCRIPTION:
+#   Tests for check-threads-count.rb
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#   This test suite mocks up a process table to be returned by Sys::ProcTable.ps()
+#
+# LICENSE:
+#   Copyright 2015 Contegix, LLC.
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
 require_relative './plugin_stub.rb'
 require_relative './spec_helper.rb'
 require_relative '../bin/check-threads-count.rb'
@@ -36,7 +57,7 @@ describe ThreadsCount, 'run' do
   it 'returns unknown if check_proctable_version returns false' do
     threadscount = ThreadsCount.new
     allow(threadscount).to receive(:count_threads).and_return(0)
-    allow(threadscount).to receive(:check_proctable_version) { false }
+    allow(threadscount).to receive(:check_proctable_version).and_return(false)
     expect(threadscount).to receive(:unknown)
     threadscount.run
   end

--- a/test/metrics-processes-threads-count_spec.rb
+++ b/test/metrics-processes-threads-count_spec.rb
@@ -1,0 +1,100 @@
+#!/usr/bin/env ruby
+#
+# metric-processes-threads-count_spec
+#
+# DESCRIPTION:
+#   Tests for metric-processes-threads-count_spec
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#
+# DEPENDENCIES:
+#
+# USAGE:
+#   bundle install
+#   rake spec
+#
+# NOTES:
+#   This test suite mocks up a process table to be returned by Sys::ProcTable.ps()
+#
+# LICENSE:
+#   Copyright 2015 Contegix, LLC.
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
+require_relative './plugin_stub.rb'
+require_relative './spec_helper.rb'
+require_relative '../bin/metrics-processes-threads-count.rb'
+
+RSpec.configure do |c|
+  c.before { allow($stdout).to receive(:puts) }
+  c.before { allow($stderr).to receive(:puts) }
+end
+
+describe ProcessesThreadsCount, 'count_threads' do
+  it 'should be able to count threads from ProcTable structs with :nlwp fields' do
+    nlwp_entry = Struct.new(:nlwp)
+    table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]
+    ptcount = ProcessesThreadsCount.new
+    expect(ptcount.count_threads(table)).to eq(10)
+  end
+
+  it 'should be able to count threads from ProcTable structs with :thread_count fields' do
+    tc_entry = Struct.new(:thread_count)
+    table = [tc_entry.new(3), tc_entry.new(1), tc_entry.new(6)]
+    ptcount = ProcessesThreadsCount.new
+    expect(ptcount.count_threads(table)).to eq(10)
+  end
+
+end
+
+describe ThreadsCount, 'run' do
+
+  it 'returns unknown if check_proctable_version returns false and config[:threads] is true' do
+    nlwp_entry = Struct.new(:thread_count)
+    table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]
+    allow(Sys::ProcTable).to receive(:ps).and_return(table)
+    ptcount = ProcessesThreadsCount.new
+    ptcount.config[:threads] = true
+    allow(ptcount).to receive(:count_threads).and_return(0)
+    allow(ptcount).to receive(:check_proctable_version).and_return(false)
+    expect(ptcount).to receive(:unknown)
+    expect(-> { ptcount.run }).to raise_error SystemExit
+  end
+
+  it 'does not return unknown if check_proctable_version returns false and config[:threads] is false' do
+    nlwp_entry = Struct.new(:thread_count)
+    table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]
+    allow(Sys::ProcTable).to receive(:ps).and_return(table)
+    ptcount = ProcessesThreadsCount.new
+    ptcount.config[:threads] = false
+    allow(ptcount).to receive(:count_threads).and_return(0)
+    allow(ptcount).to receive(:check_proctable_version).and_return(false)
+    expect(ptcount).to_not receive(:unknown)
+    expect(-> { ptcount.run }).to raise_error SystemExit
+  end
+
+  it 'outputs process and threads count metrics when config[:threads] is true' do
+    nlwp_entry = Struct.new(:thread_count)
+    table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]
+    allow(Sys::ProcTable).to receive(:ps).and_return(table)
+    ptcount = ProcessesThreadsCount.new
+    ptcount.config[:threads] = true
+    allow(ptcount).to receive(:output)
+    expect(ptcount).to receive(:output).with(match('process_count 3 '))
+    expect(ptcount).to receive(:output).with(match('thread_count 10 '))
+    expect(-> { ptcount.run }).to raise_error SystemExit
+  end
+
+  it 'does not output threads count metrics when config[:threads] is false' do
+    nlwp_entry = Struct.new(:thread_count)
+    table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]
+    allow(Sys::ProcTable).to receive(:ps).and_return(table)
+    ptcount = ProcessesThreadsCount.new
+    allow(ptcount).to receive(:output)
+    expect(ptcount).to receive(:output).with(match('process_count 3 '))
+    expect(ptcount).to_not receive(:output).with(match('threads_count 10 '))
+    expect(-> { ptcount.run }).to raise_error SystemExit
+  end
+
+end

--- a/test/plugin_stub.rb
+++ b/test/plugin_stub.rb
@@ -3,6 +3,7 @@ RSpec.configure do |c|
   # XXX: code-under-test from being run at the end of the rspec suite.
   c.before(:each) do
     Sensu::Plugin::CLI.class_eval do
+      # PluginStub
       class PluginStub
         def run; end
 
@@ -20,4 +21,3 @@ RSpec.configure do |c|
     end
   end
 end
-

--- a/test/plugin_stub.rb
+++ b/test/plugin_stub.rb
@@ -1,0 +1,23 @@
+RSpec.configure do |c|
+  # XXX: Sensu plugins run in the context of an at_exit handler. This prevents
+  # XXX: code-under-test from being run at the end of the rspec suite.
+  c.before(:each) do
+    Sensu::Plugin::CLI.class_eval do
+      class PluginStub
+        def run; end
+
+        def ok(*); end
+
+        def warning(*); end
+
+        def critical(*); end
+
+        def unknown(*); end
+      end
+      # rubocop:disable all
+      class_variable_set(:@@autorun, PluginStub)
+      # rubocop:enable all
+    end
+  end
+end
+


### PR DESCRIPTION
This PR adds two checks:

1. ```check-threads-count.rb```, which counts the number of threads running on the system and alerts if they exceed the warning or critical thresholds.
2. ```metrics-processes-threads-count.rb```, which counts the number of processes (and optionally threads) running on the system and outputs the counts as metrics.

Both checks have Windows and Linux support. They require ```sys-proctable``` >= 0.9.6 for full functionality.

Background on this is discussed in https://github.com/sensu-plugins/sensu-plugins-process-checks/issues/3.