### PR TITLE
remove default variables for :crit_under and :warn_under

### DIFF
--- a/bin/check-process.rb
+++ b/bin/check-process.rb
@@ -60,15 +60,13 @@ class CheckProcess < Sensu::Plugin::Check::CLI
          short: '-W N',
          long: '--warn-under N',
          description: 'Trigger a warning if under a number',
-         proc: proc(&:to_i),
-         default: 1
+         proc: proc(&:to_i)
 
   option :crit_under,
          short: '-C N',
          long: '--critical-under N',
          description: 'Trigger a critial if under a number',
-         proc: proc(&:to_i),
-         default: 1
+         proc: proc(&:to_i)
 
   option :metric,
          short: '-t METRIC',


### PR DESCRIPTION
I want to check if the number of zombie process if not positive with these arguments:
    
    check-process.rb -w 1 -c 2 -s Z

but in this case the script return:
    
    CheckProcess CRITICAL: Found 0 matching processes; state Z

I think we should remove the default variable of crit_under and warn_under
