### PR TITLE
Gem name appears to be case sensitive

### DIFF
--- a/bin/check-cmd.rb
+++ b/bin/check-cmd.rb
@@ -26,7 +26,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'english'
+require 'English'
 
 #
 # Check Command Status


### PR DESCRIPTION
I was getting the following on my system

```
Check failed to run: undefined method `exitstatus' for nil:NilClass, ["/etc/sensu/plugins/check-cmd.rb:58:in `acquire_cmd_status'", "/etc/sensu/plugins/check-cmd.rb:76:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.1.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

Once I change the gem to `English` the error went away