### PR TITLE
Fix default scheme to include hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Fixed
+- include hostname in default scheme in metrics-processes-threads-count
 
 ## [0.0.4] - 2015-07-14
 ### Changed

--- a/bin/metrics-processes-threads-count.rb
+++ b/bin/metrics-processes-threads-count.rb
@@ -41,7 +41,7 @@ class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Scheme for metric output',
          short: '-s SCHEME',
          long: '--scheme SCHEME',
-         default: 'system'
+         default: "#{Socket.gethostname}.system"
 
   option :threads,
          description: 'If specified, count the number of threads running on the system in addition to processes. Note: Requires sys-proctables > 0.9.5',


### PR DESCRIPTION
Default scheme "system" is not best... And it's behaviour different than most of metrics.