### PR TITLE
Require Socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
-- nothing
+### Fixed
+- require 'socket' in metrics-processes-threads-count
 
 ## [0.0.5] - 2015-07-14
 ### Fixed

--- a/bin/metrics-processes-threads-count.rb
+++ b/bin/metrics-processes-threads-count.rb
@@ -32,6 +32,7 @@
 
 require 'sensu-plugin/metric/cli'
 require 'sys/proctable'
+require 'socket'
 
 #
 # Processes and Threads Count Metrics


### PR DESCRIPTION
6bbbc22de454d94192ed7393d7b767071f3d73fa introduced a default scheme by
using `Socket.gethostname` to use the system's hostname.  However,
Socket was not required here, resulting in errors.