### PR TITLE
Added support for Red Hat "needs-restarting" script to check-process-restart.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- added support for Red Hat "needs-restarting" script to check-process-restart.rb
 
 ## [0.0.6] - 2015-08-24
 ### Fixed

--- a/bin/check-process-restart.rb
+++ b/bin/check-process-restart.rb
@@ -118,7 +118,7 @@ class CheckProcessRestart < Sensu::Plugin::Check::CLI
         m = /(\d+)\s:\s(.*)$/.match(l)
 
         if m
-          needs_restarting_hash[:pids] << { m[1] => m[2]  }
+          needs_restarting_hash[:pids] << { m[1] => m[2] }
         end
       end
     end
@@ -159,4 +159,3 @@ class CheckProcessRestart < Sensu::Plugin::Check::CLI
     end
   end
 end
-

--- a/bin/check-process-restart.rb
+++ b/bin/check-process-restart.rb
@@ -76,7 +76,7 @@ class CheckProcessRestart < Sensu::Plugin::Check::CLI
   # @return [Boolean]
   #
   def needs_restarting?
-    File.exist?('/etc/redhat-release') && File.exist?(NEEDS_RESTARTING)
+    File.exist?(NEEDS_RESTARTING)
   end
 
   # Run checkrestart and parse process(es) and pid(s)

--- a/bin/check-process-restart.rb
+++ b/bin/check-process-restart.rb
@@ -13,7 +13,7 @@
 #             WARNING if 1 process requires a restart
 #
 # PLATFORMS:
-#   Linux (Debian based distributions)
+#   Linux
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
@@ -26,8 +26,9 @@
 #   check-process-restart.rb -w 2 -c 5
 #
 # NOTES:
-#   This will only work on Debian based distributions and requires the
-#   debian-goodies package.
+#   This will only work on Debian or Red Hat-based distributions.
+#   In the case of Debian-based distributions, the debian-goodies
+#   package will need to be installed.
 #
 #   Also make sure the user "sensu" can sudo without password
 #
@@ -55,6 +56,9 @@ class CheckProcessRestart < Sensu::Plugin::Check::CLI
   # Debian command to run
   CHECK_RESTART = '/usr/sbin/checkrestart'.freeze
 
+  # Red Hat command to run
+  NEEDS_RESTARTING = '/usr/bin/needs-restarting'.freeze
+
   # Set path for the checkrestart script
   #
   def initialize
@@ -66,6 +70,13 @@ class CheckProcessRestart < Sensu::Plugin::Check::CLI
   #
   def checkrestart?
     File.exist?('/etc/debian_version') && File.exist?(CHECK_RESTART)
+  end
+
+  # Check if we can run needs-restarting script
+  # @return [Boolean]
+  #
+  def needs_restarting?
+    File.exist?('/etc/redhat-release') && File.exist?(NEEDS_RESTARTING)
   end
 
   # Run checkrestart and parse process(es) and pid(s)
@@ -92,21 +103,60 @@ class CheckProcessRestart < Sensu::Plugin::Check::CLI
     checkrestart_hash
   end
 
+  # Run needs-restarting and parse process(es) and pid(s)
+  # @return [Hash]
+  def run_needs_restarting
+    needs_restarting_hash = { found: '', pids: [] }
+
+    out = `sudo #{NEEDS_RESTARTING} 2>&1`
+    if $CHILD_STATUS.to_i != 0
+      needs_restarting_hash[:found] = "Failed to run needs-restarting: #{out}"
+    else
+      needs_restarting_hash[:found] = `sudo #{NEEDS_RESTARTING} | wc -l | tr -d "\n"`
+
+      out.lines do |l|
+        m = /(\d+)\s:\s(.*)$/.match(l)
+
+        if m
+          needs_restarting_hash[:pids] << { m[1] => m[2]  }
+        end
+      end
+    end
+    needs_restarting_hash
+  end
+
   # Main run method for the check
   #
   def run
-    unless checkrestart?
-      unknown "Can't seem to find checkrestart. This check only works in a Debian based distribution and you need debian-goodies package installed"
-    end
+    if checkrestart?
+      checkrestart_out = run_checkrestart
 
-    checkrestart_out = run_checkrestart
-    if /^Failed/ =~ checkrestart_out[:found]
-      unknown checkrestart_out[:found]
+      if /^Failed/ =~ checkrestart_out[:found]
+        unknown checkrestart_out[:found]
+      end
+
+      message JSON.generate(checkrestart_out)
+      found = checkrestart_out[:found].to_i
+
+      warning if found >= config[:warn].to_i && found < config[:crit].to_i
+      critical if found >= config[:crit].to_i
+      ok
+    elsif needs_restarting?
+      needs_restarting_out = run_needs_restarting
+
+      if /^Failed/ =~ needs_restarting_out[:found]
+        unknown needs_restarting_out[:found]
+      end
+
+      message JSON.generate(needs_restarting_out)
+      found = needs_restarting_out[:found].to_i
+
+      warning if found >= config[:warn].to_i && found < config[:crit].to_i
+      critical if found >= config[:crit].to_i
+      ok
+    else
+      unknown "Can't seem to find either checkrestart or needs-restarting. For checkrestart, you will need to install the debian-goodies package."
     end
-    message JSON.generate(checkrestart_out)
-    found = checkrestart_out[:found].to_i
-    warning if found >= config[:warn].to_i && found < config[:crit].to_i
-    critical if found >= config[:crit].to_i
-    ok
   end
 end
+

--- a/bin/check-threads-count.rb
+++ b/bin/check-threads-count.rb
@@ -68,9 +68,9 @@ class ThreadsCount < Sensu::Plugin::Check::CLI
   # Returns the number of processes in those fields.
   # Otherwise, returns 1 as all processes are assumed to have at least one thread.
   def get_process_threads(p)
-    if p.respond_to?(:nlwp)
+    if p.respond_to?(:nlwp) # rubocop:disable Style/GuardClause
       return test_int(p.nlwp)
-    elsif p.respond_to?(:thread_count) # rubocop:disable Style/GuardClause
+    elsif p.respond_to?(:thread_count)
       return test_int(p.thread_count)
     else
       return 1

--- a/bin/metrics-processes-threads-count.rb
+++ b/bin/metrics-processes-threads-count.rb
@@ -71,9 +71,9 @@ class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
   # Returns the number of processes in those fields.
   # Otherwise, returns 1 as all processes are assumed to have at least one thread.
   def get_process_threads(p)
-    if p.respond_to?(:nlwp)
+    if p.respond_to?(:nlwp) # rubocop:disable Style/GuardClause
       return test_int(p.nlwp)
-    elsif p.respond_to?(:thread_count) # rubocop:disable Style/GuardClause
+    elsif p.respond_to?(:thread_count)
       return test_int(p.thread_count)
     else
       return 1

--- a/sensu-plugins-process-checks.gemspec
+++ b/sensu-plugins-process-checks.gemspec
@@ -25,8 +25,7 @@ Gem::Specification.new do |s|
                                'development_status' => 'active',
                                'production_status'  => 'unstable - testing recommended',
                                'release_draft'      => 'false',
-                               'release_prerelease' => 'false'
-                              }
+                               'release_prerelease' => 'false' }
   s.name                   = 'sensu-plugins-process-checks'
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
@@ -47,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.37'
+  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
- check-process-restart.rb is a very useful plugin for checking when a process needs to be restarted (such as after a critical security update to OpenSSL). However, it currently only supports Debian's **checkrestart** script and not Red Hat's **needs-restarting** script. Adding this functionality should provide support for Red Hat Enterprise Linux, CentOS, Amazon Linux, Scientific Linux, Oracle Linux, etc.

- Tested on CentOS 6, CentOS 7 and Amazon Linux.