### PR TITLE
Allow additional args to be passed to underlying tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - check-process.rb: Flip the meaning of `-z`, `-r`, `-P` and `-T` to match what the help messages say they do.
 
+### Added
+- check-process-restart.rb: Allow additional arguments to be passed to the underlying tool using `-a`.
+
 ## [1.0.0] - 2016-06-21
 ### Fixed
 - metrics-per-process.py: avoid false alerts by adding exception handling for `OSError` errors


### PR DESCRIPTION
We need to send a particular arg to checkrestart to filter out some
false positives.

This change allows for any additional args to be passed through - rather
than restricting to the current known args. We have allowed it for
checkrestart and the needs-restarting tool since we don't know for
sure what options needs-restarting can take.

Have also appeased rubocop in the command status checking.
