### PR TITLE
check-process.rb: return CRITICAL if pid file is specified and does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - check-process.rb: Flip the meaning of `-z`, `-r`, `-P` and `-T` to match what the help messages say they do.
 
+### Changed
+- check-process.rb: return CRITICAL if pid file is specified and does not exist
+
 ## [1.0.0] - 2016-06-21
 ### Fixed
 - metrics-per-process.py: avoid false alerts by adding exception handling for `OSError` errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-process.rb: Flip the meaning of `-z`, `-r`, `-P` and `-T` to match what the help messages say they do.
 
 ### Changed
-- check-process.rb: return false on pid file failed read and let the configurable options to define check response
+- check-process.rb: Added `-F` option to trigger a critical if pid file is specified but non-existent.
 
 ### Added
 - check-process-restart.rb: Allow additional arguments to be passed to the underlying tool using `-a`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-process.rb: Flip the meaning of `-z`, `-r`, `-P` and `-T` to match what the help messages say they do.
 
 ### Changed
-- check-process.rb: return CRITICAL if pid file is specified and does not exist
+- check-process.rb: return false on pid file failed read and let the configurable options to define check response
 
 ## [1.0.0] - 2016-06-21
 ### Fixed

--- a/bin/check-process.rb
+++ b/bin/check-process.rb
@@ -177,7 +177,7 @@ class CheckProcess < Sensu::Plugin::Check::CLI
     if File.exist?(path)
       File.read(path).strip.to_i
     else
-      unknown "Could not read pid file #{path}"
+      critical "Could not read pid file #{path}"
     end
   end
 


### PR DESCRIPTION
## Pull Request Checklist

Addressing #23 . 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

I encountered the same issue.

If pid file is specified, it is expected that the pid file must exist and contain pid to match. If pid file becomes non-existent, it very likely means that the monitored process cease to run (or the check should be treated as 'fail' because the pid file given is invalid) and check-process.rb check is expected to return CRITICAL rather than UNKNOWN. 


#### Known Compatablity Issues

Technically, none.