### PR TITLE
fixes #36 by renaming flag to actually alert based on the data it is pulling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-### Fixed
-- check-process.rb: Flip the meaning of `-z`, `-r`, `-P` and `-T` to match what the help messages say they do.
+### Breaking Changes
+- check-process.rb: renamed `--propotional-set-size` to `--cpu-utilization` as that's really what it was. (@majormoses)
+- check-process.rb: Flip the meaning of `-z`, `-r`, `-P` and `-T` to match what the help messages say they do. (@maoe)
 
 ### Changed
-- check-process.rb: Added `-F` option to trigger a critical if pid file is specified but non-existent.
+- check-process.rb: Added `-F` option to trigger a critical if pid file is specified but non-existent. (@swibowo)
 
 ### Added
-- check-process-restart.rb: Allow additional arguments to be passed to the underlying tool using `-a`.
+- check-process-restart.rb: Allow additional arguments to be passed to the underlying tool using `-a`. (@tomduckering)
 
 ## [1.0.0] - 2016-06-21
 ### Fixed

--- a/bin/check-process.rb
+++ b/bin/check-process.rb
@@ -123,9 +123,9 @@ class CheckProcess < Sensu::Plugin::Check::CLI
          description: 'Trigger on a Resident Set size is bigger than this',
          proc: proc(&:to_i)
 
-  option :pcpu,
-         short: '-P PCPU',
-         long: '--proportional-set-size PCPU',
+  option :cpu_utilization,
+         short: '-P xx',
+         long: '--cpu-utilization xx',
          description: 'Trigger on a Proportional Set Size is bigger than this',
          proc: proc(&:to_f)
 
@@ -228,7 +228,7 @@ class CheckProcess < Sensu::Plugin::Check::CLI
       end
     else
       read_lines('ps axwwo user,pid,vsz,rss,pcpu,nlwp,state,etime,time,command').drop(1).map do |line|
-        line_to_hash(line, :user, :pid, :vsz, :rss, :pcpu, :thcount, :state, :etime, :time, :command)
+        line_to_hash(line, :user, :pid, :vsz, :rss, :cpu, :thcount, :state, :etime, :time, :command)
       end
     end
   end
@@ -262,7 +262,7 @@ class CheckProcess < Sensu::Plugin::Check::CLI
     procs.reject! { |p| p[:command] !~ /#{config[:cmd_pat]}/ } if config[:cmd_pat]
     procs.select! { |p| p[:vsz].to_f > config[:vsz] } if config[:vsz]
     procs.select! { |p| p[:rss].to_f > config[:rss] } if config[:rss]
-    procs.select! { |p| p[:pcpu].to_f > config[:pcpu] } if config[:pcpu]
+    procs.select! { |p| p[:cpu].to_f > config[:cpu_utilization] } if config[:cpu_utilization]
     procs.select! { |p| p[:thcount].to_i > config[:thcount] } if config[:thcount]
     procs.reject! { |p| etime_to_esec(p[:etime]) >= config[:esec_under] } if config[:esec_under]
     procs.reject! { |p| etime_to_esec(p[:etime]) <= config[:esec_over] } if config[:esec_over]
@@ -277,7 +277,7 @@ class CheckProcess < Sensu::Plugin::Check::CLI
     msg += "; user #{config[:user].join(',')}" if config[:user]
     msg += "; vsz > #{config[:vsz]}" if config[:vsz]
     msg += "; rss > #{config[:rss]}" if config[:rss]
-    msg += "; pcpu > #{config[:pcpu]}" if config[:pcpu]
+    msg += "; cpu > #{config[:cpu_utilization]}" if config[:cpu_utilization]
     msg += "; thcount > #{config[:thcount]}" if config[:thcount]
     msg += "; esec < #{config[:esec_under]}" if config[:esec_under]
     msg += "; esec > #{config[:esec_over]}" if config[:esec_over]


### PR DESCRIPTION
Example useage:
crit:
```
$ ./bin/check-process.rb -p 'slack' --cpu-utilization 2 --critical-under 0 --warn-under 0 --critical-over 0
CheckProcess CRITICAL: Found 1 matching processes; cmd /slack/; cpu > 2.0
```
ok:
```
$ ./bin/check-process.rb -p 'slack' --cpu-utilization 5 --critical-under 0 --warn-under 0 --critical-over 0
CheckProcess OK: Found 0 matching processes; cmd /slack/; cpu > 5.0
```

## Pull Request Checklist

#36 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Make the code do what it thinks it's doing.
#### Known Compatibility Issues
None, only tested linux unknown if bsd is different.
