### PR TITLE
Add binstubs for non-Ruby scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+### Added
+- metrics-per-process.rb: Binstub for metrics-per-process.py
+- metrics-process-uptime.rb: Binstub for metrics-process-uptime.sh
+
 ## [2.0.0] 2017-05-18
 ### Breaking Changes
 - check-process.rb: renamed `--propotional-set-size` to `--cpu-utilization` as that's really what it was. (@majormoses)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@
  * bin/check-process-restart.rb
  * bin/check-process.rb
  * bin/check-threads-count.rb
+ * bin/metrics-per-process.py
+ * bin/metrics-per-process.rb
  * bin/metrics-process-status.rb
- * bin/metrics-processes-threads-count.rb
+ * bin/metrics-process-uptime.rb
  * bin/metrics-process-uptime.sh
+ * bin/metrics-processes-threads-count.rb
 
 ## Usage
 

--- a/bin/metrics-per-process.rb
+++ b/bin/metrics-per-process.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+bin_dir = File.expand_path(File.dirname(__FILE__))
+shell_script_path = File.join(bin_dir, File.basename($PROGRAM_NAME, '.rb') + '.py')
+
+exec shell_script_path, *ARGV

--- a/bin/metrics-process-uptime.rb
+++ b/bin/metrics-process-uptime.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+bin_dir = File.expand_path(File.dirname(__FILE__))
+shell_script_path = File.join(bin_dir, File.basename($PROGRAM_NAME, '.rb') + '.sh')
+
+exec shell_script_path, *ARGV


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Adds two binstubs for the two non-Ruby scripts, `metrics-per-process.py` and `metrics-processes-threads-count.rb`.