### PR TITLE
Add Python 2.6 support for metrics-per-process.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- metrics-per-process.py: Fallback to importing Counter from backport_collections for Python 2.6 support.
+
 ## [2.1.0] - 2017-05-25
 ### Added
 - metrics-per-process.rb: Binstub for metrics-per-process.py

--- a/bin/metrics-per-process.py
+++ b/bin/metrics-per-process.py
@@ -11,7 +11,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#  Python 2.7+ (untested on Python3, should work though)
+#  Python 2.6+ (untested on Python3, should work though)
 #  Python module: psutil https://pypi.python.org/pypi/psutil
 #
 # USAGE:
@@ -68,8 +68,11 @@ import optparse
 import psutil
 import sys
 import time
-from collections import Counter
 
+try:
+  from collections import Counter
+except ImportError:
+  from backport_collections import Counter
 
 PROC_ROOT_DIR = '/proc/'
 TCP_CONN_STATUSES = [
@@ -221,4 +224,3 @@ def main():
 #
 if __name__ == '__main__':
   main()
-


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Allows the metrics-per-process.py check to work in Python 2.6 environments by falling back to importing the Counter module from the backport_collections library.

#### Known Compatibility Issues

None.