### PR TITLE
Use memory_info() instead of deprecated memory_info_ex() in metrics-per-process.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changed
+- metrics-per-process.py: Use memory_info() in psutil versions greater than 4.0.0, as memory_info_ex() was deprecated.
+
 ## [2.2.0] - 2017-05-28
 ### Changed
 - metrics-per-process.py: Fallback to importing Counter from backport_collections for Python 2.6 support.

--- a/bin/metrics-per-process.py
+++ b/bin/metrics-per-process.py
@@ -114,17 +114,21 @@ def stats_per_pid(pid):
 
   stats = {}
   process_handler = psutil.Process(pid)
+  if psutil.version_info < (4,0,0):
+    process_memory_info = process_handler.memory_info_ex()
+  else:
+    process_memory_info = process_handler.memory_info()
   stats['cpu.user'] = process_handler.cpu_times().user
   stats['cpu.system'] = process_handler.cpu_times().system
   stats['cpu.percent'] = process_handler.cpu_percent()
   stats['threads'] = process_handler.num_threads()
-  stats['memory.rss'] = process_handler.memory_info_ex().rss
-  stats['memory.vms'] = process_handler.memory_info_ex().vms
-  stats['memory.shared'] = process_handler.memory_info_ex().shared
-  stats['memory.text'] = process_handler.memory_info_ex().text
-  stats['memory.lib'] = process_handler.memory_info_ex().lib
-  stats['memory.data'] = process_handler.memory_info_ex().data
-  stats['memory.dirty'] = process_handler.memory_info_ex().dirty
+  stats['memory.rss'] = process_memory_info.rss
+  stats['memory.vms'] = process_memory_info.vms
+  stats['memory.shared'] = process_memory_info.shared
+  stats['memory.text'] = process_memory_info.text
+  stats['memory.lib'] = process_memory_info.lib
+  stats['memory.data'] = process_memory_info.data
+  stats['memory.dirty'] = process_memory_info.dirty
   stats['memory.percent'] = process_handler.memory_percent()
   stats['fds'] = process_handler.num_fds()
   stats['ctx_switches.voluntary'] = process_handler.num_ctx_switches().voluntary


### PR DESCRIPTION
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

psutil's `memory_info_ex()` method was deprecated in their 4.0.0 release. This uses the updated `memory_info()` method in 4.0.0+, and the old method in previous versions, to eliminate deprecation notice warnings from the check.

#### Known Compatibility Issues

None.
