### PR TITLE
remove checks that do not actually make sense anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Changed
+- bump and loosen dependency of `sys-proctable` (@majormoses)
+
+### Removed
+- check-threads-count.rb, metrics-processes-threads-count.rb: checks on `sys-proctable` versions as we now require new enough versions. (@majormoses)
+
 ## [2.5.0] - 2017-10-04
 ### Added
 - metric-per-processes.py: Add metrics filter (@rthouvenin)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 
 ### Changed
-- bump and loosen dependency of `sys-proctable` (@majormoses)
+- loosen dependency of `sys-proctable` (@majormoses)
 
 ### Removed
 - check-threads-count.rb, metrics-processes-threads-count.rb: checks on `sys-proctable` versions as we now require new enough versions. (@majormoses)

--- a/bin/check-threads-count.rb
+++ b/bin/check-threads-count.rb
@@ -48,13 +48,6 @@ class ThreadsCount < Sensu::Plugin::Check::CLI
          default: 32_000,
          proc: proc(&:to_i)
 
-  PROCTABLE_MSG = 'sys-proctable version newer than 0.9.5 is required for counting threads with -t or --threads'.freeze
-
-  # Exit with an unknown if sys-proctable is not high enough to support counting threads.
-  def check_proctable_version
-    Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5')
-  end
-
   # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1.
   # See the comments on get_process_threads() for why 1 is returned.
   def test_int(i)
@@ -86,13 +79,9 @@ class ThreadsCount < Sensu::Plugin::Check::CLI
 
   # Main function
   def run
-    if !check_proctable_version
-      unknown PROCTABLE_MSG unless check_proctable_version
-    else
-      threads = count_threads
-      critical "#{threads} threads running, over threshold #{config[:crit]}" if threads > config[:crit]
-      warning "#{threads} threads running, over threshold #{config[:warn]}" if threads > config[:warn]
-      ok "#{threads} threads running"
-    end
+    threads = count_threads
+    critical "#{threads} threads running, over threshold #{config[:crit]}" if threads > config[:crit]
+    warning "#{threads} threads running, over threshold #{config[:warn]}" if threads > config[:warn]
+    ok "#{threads} threads running"
   end
 end

--- a/bin/metrics-processes-threads-count.rb
+++ b/bin/metrics-processes-threads-count.rb
@@ -58,13 +58,6 @@ class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
          boolean: true,
          default: false
 
-  PROCTABLE_MSG = 'sys-proctable version newer than 0.9.5 is required for counting threads with -t or --threads'.freeze
-
-  # Exit with an unknown if sys-proctable is not high enough to support counting threads.
-  def check_proctable_version
-    Gem.loaded_specs['sys-proctable'].version > Gem::Version.create('0.9.5')
-  end
-
   # Takes a value to be tested as an integer. If a new Integer instance cannot be created from it, return 1.
   # See the comments on get_process_threads() for why 1 is returned.
   def test_int(i)
@@ -112,9 +105,6 @@ class ProcessesThreadsCount < Sensu::Plugin::Metric::CLI::Graphite
 
   # Main function
   def run
-    if config[:threads] || config[:statuses]
-      unknown PROCTABLE_MSG unless check_proctable_version
-    end
     ps_table = Sys::ProcTable.ps
     processes = ps_table.length
     threads = count_threads(ps_table) if config[:threads]

--- a/sensu-plugins-process-checks.gemspec
+++ b/sensu-plugins-process-checks.gemspec
@@ -33,15 +33,15 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'english', '0.6.3'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'sys-proctable', '0.9.8'
+  s.add_runtime_dependency 'sys-proctable', '~> 1.1'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
+  s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
   s.add_development_dependency 'rubocop',                   '~> 0.40.0'
-  s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/sensu-plugins-process-checks.gemspec
+++ b/sensu-plugins-process-checks.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'english', '0.6.3'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'sys-proctable', '~> 1.1'
+  s.add_runtime_dependency 'sys-proctable', '~> 0.9.8'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/test/check-threads-count_spec.rb
+++ b/test/check-threads-count_spec.rb
@@ -52,14 +52,6 @@ describe ThreadsCount, 'count_threads' do
 end
 
 describe ThreadsCount, 'run' do
-  it 'returns unknown if check_proctable_version returns false' do
-    threadscount = ThreadsCount.new
-    allow(threadscount).to receive(:count_threads).and_return(0)
-    allow(threadscount).to receive(:check_proctable_version).and_return(false)
-    expect(threadscount).to receive(:unknown)
-    threadscount.run
-  end
-
   it 'returns critical if count_threads returns more than the critical threshold' do
     threadscount = ThreadsCount.new
     threadscount.config[:warn] = 10

--- a/test/metrics-processes-threads-count_spec.rb
+++ b/test/metrics-processes-threads-count_spec.rb
@@ -48,18 +48,6 @@ describe ProcessesThreadsCount, 'count_threads' do
 end
 
 describe ThreadsCount, 'run' do
-  it 'returns unknown if check_proctable_version returns false and config[:threads] is true' do
-    nlwp_entry = Struct.new(:thread_count)
-    table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]
-    allow(Sys::ProcTable).to receive(:ps).and_return(table)
-    ptcount = ProcessesThreadsCount.new
-    ptcount.config[:threads] = true
-    allow(ptcount).to receive(:count_threads).and_return(0)
-    allow(ptcount).to receive(:check_proctable_version).and_return(false)
-    expect(ptcount).to receive(:unknown)
-    expect(-> { ptcount.run }).to raise_error SystemExit
-  end
-
   it 'does not return unknown if check_proctable_version returns false and config[:threads] is false' do
     nlwp_entry = Struct.new(:thread_count)
     table = [nlwp_entry.new(3), nlwp_entry.new(1), nlwp_entry.new(6)]


### PR DESCRIPTION
We previously checked if `sys-proctable` was greater than `0.9.8` when it was originally introduced in https://github.com/sensu-plugins/sensu-plugins-process-checks/commit/32044984dcb647ff63260435ebfd3d96894a26a0#diff-681f43ba752e5217d82b23a247fd5c79 it was `0.9.6` which would have fit this condition. We are currently requiring `0.9.8` which makes this check of no real value. We are now requiring `~> 1.1`.

On top of that I am not sure the [logic](https://github.com/sensu-plugins/sensu-plugins-process-checks/blob/2.5.0/bin/check-threads-count.rb#L89-L91) actually was ever correct but I don't care enough to check if that is right as it is now irrelevant.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist
fixes #54 

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Remove bitrot code and solve #54 at the same time.
#### Known Compatibility Issues
:man_shrugging: 