### PR TITLE
Add option to metrics-per-process.py to find PIDs by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 
 ## [Unreleased]
+### Changed
+- metrics-per-processes.py: Add option to find processes by username (@rthouvenin)
 
 ## [2.6.0] - 2017-12-05
 ### Changed


### PR DESCRIPTION
I have use cases for metrics-per-process.py where there is several processes to aggregate (so pid file is not an option) and these processes run on the same executable as other unrelated processes (so finding by name is not an option either). A typical example is several services running on python or ruby. Searching processes by name will catch too many of them.

A way to solve this is to differentiate the processes by the user running them (it is common that a service is run by its own user).

This PR adds an option to metrics-per-process.py to find PIDs by the name of the user running the process. The user running the process is determined by inspecting the owner of the proc directory of the process.

Here is a gist with the output of a few test runs: https://gist.github.com/rthouvenin/9cd4a9802acec158f326725672475e72