### PR TITLE
Support TASK_IDLE process status.  Include IDLE process in UNINTERRUPTIBLE metric for backward compatibility. Add new option to separate out metric if desired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 
 ## [Unreleased]
+### Fixed
+- metrics-processes-threads-count.rb:  Backward compatible support for TASK_IDLE process state in Linux 4.14+ (@awangptc)
+
+### Added
+- metrics-processes-threads-count.rb:  Add option to separate out TASK_IDLE process into it's own metric (@awangptc)
+
 
 ## [3.1.0] - 2018-05-02
 ### Added

--- a/test/metrics-processes-threads-count_spec.rb
+++ b/test/metrics-processes-threads-count_spec.rb
@@ -45,6 +45,30 @@ describe ProcessesThreadsCount, 'count_threads' do
     ptcount = ProcessesThreadsCount.new
     expect(ptcount.count_threads(table)).to eq(10)
   end
+
+  it 'should be able to count processes in each state - count I toward D for 4.14+ kernels' do
+    states = %w[S R D T t X Z I]
+    ps_entry = Struct.new(:state)
+    table = states.map { |state| ps_entry.new(state) }
+    ptcount = ProcessesThreadsCount.new
+    counts = ptcount.count_processes_by_status(table)
+    states.each do |state|
+      expect(counts[state]).to eq(2) if state == 'D'
+      expect(counts[state]).to be_nil if state == 'I'
+    end
+  end
+
+  it 'should be able to count processes in each state with :idle_state enabled - count I separate' do
+    states = %w[S R D T t X Z I]
+    ps_entry = Struct.new(:state)
+    table = states.map { |state| ps_entry.new(state) }
+    ptcount = ProcessesThreadsCount.new
+    ptcount.config[:idle_state] = true
+    counts = ptcount.count_processes_by_status(table)
+    states.each do |state|
+      expect(counts[state]).to eq(1)
+    end
+  end
 end
 
 describe ThreadsCount, 'run' do


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
https://github.com/sensu-plugins/sensu-plugins-process-checks/issues/65

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [N/A] Update README with any necessary configuration snippets

- [N/A] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Support new changes to process state in kernel 4.14+

#### Known Compatibility Issues
