### PR TITLE
fix check always returning critical

### DIFF
--- a/bin/metrics-ipcs.rb
+++ b/bin/metrics-ipcs.rb
@@ -60,6 +60,7 @@ class MetricsIPCS < Sensu::Plugin::Metric::CLI::Graphite
         result = line.match(/[[:space:]]*(?<name>[a-zA-Z ]*).*(?<value>\d+)/)
         output "#{config[:scheme]}.#{key}.#{result[:name].strip.tr(' ', '-')}", result[:value].strip
       end
+      found = true
     end
     if found
       ok


### PR DESCRIPTION
found is initialized to false and no condition sets it to true, consequently the checks always exits as critical.

## Pull Request Checklist

**Is this in reference to an existing issue?**

No.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
