### PR TITLE
Fix dependencies issue on english

### DIFF
--- a/sensu-plugins-process-checks.gemspec
+++ b/sensu-plugins-process-checks.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s| # rubocop: disable Metrics/BlockLength
   s.add_runtime_dependency 'sensu-plugin', '~> 4.0'
   s.add_runtime_dependency 'sys-proctable', '~> 0.9.8'
 
-  s.add_development_dependency 'bundler',                   '~> 1.7'
+  s.add_development_dependency 'bundler',                   '~> 2.1'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'pry',                       '~> 0.10'

--- a/sensu-plugins-process-checks.gemspec
+++ b/sensu-plugins-process-checks.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s| # rubocop: disable Metrics/BlockLength
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsProcessChecks::Version::VER_STRING
 
-  s.add_runtime_dependency 'english', '0.6.3'
+  s.add_runtime_dependency 'english', '0.7.0'
   s.add_runtime_dependency 'sensu-plugin', '~> 4.0'
   s.add_runtime_dependency 'sys-proctable', '~> 0.9.8'
 


### PR DESCRIPTION
Fix https://github.com/sensu-plugins/sensu-plugins-process-checks/issues/112
english 0.6.3 removed, upgrade to 0.7.0 solving the issue.
```
[root@foo001 ~]# /opt/sensu/embedded/bin/gem install -v 4.1.0 --no-rdoc --no-ri sensu-plugins-process-checks
ERROR:  Could not find a valid gem 'english' (= 0.6.3) in any repository
ERROR:  Possible alternatives: english
```

## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes
#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Fix #112 
#### Known Compatibility Issues
